### PR TITLE
Update for PEAK 1.7 - Localization update

### DIFF
--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -134,14 +134,16 @@ public class SettingsRegistry
     }
 }
 
-// strip "LOC: " prefix when localisation key is missing
+// Prefix patch to skip LOC fallback
 [HarmonyPatch(typeof(LocalizedText), "GetText", new Type[] { typeof(string), typeof(bool) })]
-static class StripLocPrefixPatch
+static class GetTextPrefixPatch
 {
-    static void Postfix(ref string __result)
+    static bool Prefix(string id, bool printDebug, ref string __result)
     {
-        const string prefix = "LOC: ";
-        if (__result.StartsWith(prefix))
-            __result = __result.Substring(prefix.Length);
+        id = id.ToUpperInvariant();
+        if (LocalizedText.mainTable.TryGetValue(id, out var row))
+            return true;
+        __result = id;
+        return false;
     }
 }

--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -57,7 +57,6 @@ public class Plugin : BaseUnityPlugin
         }
 
         updateTabsRoutine = StartCoroutine(UpdateTabs(scene));
-        SceneManager.sceneLoaded -= OnSceneLoaded;
     }
 
     private IEnumerator UpdateTabs(Scene scene)

--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx;
+using BepInEx;
 using BepInEx.Logging;
 using HarmonyLib;
 using System;
@@ -15,23 +15,18 @@ public class Plugin : BaseUnityPlugin
 {
     internal static new ManualLogSource Logger;
     private GameObject buttonSrc;
+    private Coroutine updateTabsRoutine;
         
     private void Awake()
     {
-        // Plugin startup logic
         Logger = base.Logger;
         Logger.LogInfo($"Plugin {MyPluginInfo.PLUGIN_GUID} is loaded!");
+        new Harmony(MyPluginInfo.PLUGIN_GUID).PatchAll();
     }
 
-    private void Start()
-    {
-        //
-    }
+    private void Start() { }
 
-    private void OnEnable()
-    {
-        SceneManager.sceneLoaded += OnSceneLoaded;
-    }
+    private void OnEnable()  => SceneManager.sceneLoaded += OnSceneLoaded;
 
     private void OnDisable()
     {
@@ -43,16 +38,14 @@ public class Plugin : BaseUnityPlugin
         }
     }
 
-    private Coroutine updateTabsRoutine;
-
     private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
     {
+        buttonSrc = null;
         if (updateTabsRoutine != null)
         {
             StopCoroutine(updateTabsRoutine);
             updateTabsRoutine = null;
         }
-
         updateTabsRoutine = StartCoroutine(UpdateTabs(scene));
     }
 
@@ -60,26 +53,30 @@ public class Plugin : BaseUnityPlugin
     {
         Logger.LogInfo("Scene loadeeeed: " + scene.name);
 
-        while (buttonSrc == null) {
+        while (buttonSrc == null)
+        {
             List<SettingsTABSButton> buttons = FindAllInScene(scene);
-            if (buttons.Count != 0) {
+            if (buttons.Count != 0)
                 buttonSrc = buttons[0].gameObject;
-            }
             yield return new WaitForSeconds(.050f);
         }
 
-        if (buttonSrc != null)
-        {
-            Logger.LogInfo("Found TABS/General");
+        foreach (Transform child in buttonSrc.transform.parent)
+            if (child != buttonSrc.transform)
+                Destroy(child.gameObject);
 
-            foreach (var (name, category) in SettingsRegistry.GetPages())
-            {
-                Logger.LogInfo($"Creating {name} with category {category}");
-                GameObject newButton = Instantiate(buttonSrc, buttonSrc.transform.parent);
-                SettingsTABSButton tabsButton = newButton.GetComponent<SettingsTABSButton>();
-                tabsButton.category = category;
-                tabsButton.text.text = name;
-            }
+        Logger.LogInfo("Found TABS/General");
+
+        foreach (var (name, category) in SettingsRegistry.GetPages())
+        {
+            Logger.LogInfo($"Creating {name} with category {category}");
+            GameObject newButton = Instantiate(buttonSrc, buttonSrc.transform.parent);
+            var loc = newButton.GetComponentInChildren<LocalizedText>();
+            // Fix General tab issue: remove LocalizedText so our custom tab name isn't overwritten
+            if (loc != null) Destroy(loc);
+            SettingsTABSButton tabsButton = newButton.GetComponent<SettingsTABSButton>();
+            tabsButton.category = category;
+            tabsButton.text.text = name;
         }
     }
 
@@ -87,10 +84,7 @@ public class Plugin : BaseUnityPlugin
     {
         var result = new List<SettingsTABSButton>();
         foreach (var root in scene.GetRootGameObjects())
-        {
-            var found = root.GetComponentsInChildren<SettingsTABSButton>();
-            result.AddRange(found);
-        }
+            result.AddRange(root.GetComponentsInChildren<SettingsTABSButton>(true));
         return result;
     }
 }
@@ -101,24 +95,26 @@ public class SettingsRegistry
 
     public static void Register(string name)
     {
-        if (!nameToCategoryId.ContainsKey(name))
-        {
-            SettingsCategory highestId = Enum.GetValues(typeof(SettingsCategory)).Cast<SettingsCategory>().Max();
-            if (nameToCategoryId.Count != 0)
-            {
-                highestId = nameToCategoryId.Values.Max();
-            }
+        if (nameToCategoryId.ContainsKey(name)) return;
 
-            nameToCategoryId[name] = highestId + 1;
-        }
+        int builtInMax = Enum.GetValues(typeof(SettingsCategory)).Cast<int>().Max();
+        int customMax  = nameToCategoryId.Count == 0 ? 0 : nameToCategoryId.Values.Max(v => (int)v);
+        nameToCategoryId[name] = (SettingsCategory)(Math.Max(builtInMax, customMax) + 1);
     }
 
-    public static string GetPageId(string name)
+    public static string GetPageId(string name) => nameToCategoryId[name].ToString();
+
+    public static Dictionary<string, SettingsCategory> GetPages() => nameToCategoryId;
+}
+
+/* Strip “LOC: ” prefix when localisation key is missing */
+[HarmonyPatch(typeof(LocalizedText), "GetText", new Type[] { typeof(string), typeof(bool) })]
+static class StripLocPrefixPatch
+{
+    static void Postfix(ref string __result)
     {
-        return nameToCategoryId[name].ToString();
-    }
-
-    public static Dictionary<string, SettingsCategory> GetPages() {
-        return nameToCategoryId;
+        const string prefix = "LOC: ";
+        if (__result.StartsWith(prefix))
+            __result = __result.Substring(prefix.Length);
     }
 }

--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -136,10 +136,10 @@ static class GetTextPrefixPatch
 {
     static bool Prefix(string id, bool printDebug, ref string __result)
     {
-        id = id.ToUpperInvariant();
-        if (LocalizedText.mainTable.TryGetValue(id, out var row))
+        var upper = id.ToUpperInvariant();
+        if (LocalizedText.mainTable.TryGetValue(upper, out var row))
             return true;
-        __result = id;
+        __result = upper;
         return false;
     }
 }

--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -15,18 +15,24 @@ public class Plugin : BaseUnityPlugin
 {
     internal static new ManualLogSource Logger;
     private GameObject buttonSrc;
-    private Coroutine updateTabsRoutine;
         
     private void Awake()
     {
+        // Plugin startup logic
         Logger = base.Logger;
         Logger.LogInfo($"Plugin {MyPluginInfo.PLUGIN_GUID} is loaded!");
         new Harmony(MyPluginInfo.PLUGIN_GUID).PatchAll();
     }
 
-    private void Start() { }
+    private void Start()
+    {
+        //
+    }
 
-    private void OnEnable()  => SceneManager.sceneLoaded += OnSceneLoaded;
+    private void OnEnable()
+    {
+        SceneManager.sceneLoaded += OnSceneLoaded;
+    }
 
     private void OnDisable()
     {
@@ -38,14 +44,18 @@ public class Plugin : BaseUnityPlugin
         }
     }
 
+    private Coroutine updateTabsRoutine;
+
     private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
     {
         buttonSrc = null;
+
         if (updateTabsRoutine != null)
         {
             StopCoroutine(updateTabsRoutine);
             updateTabsRoutine = null;
         }
+
         updateTabsRoutine = StartCoroutine(UpdateTabs(scene));
     }
 
@@ -53,30 +63,34 @@ public class Plugin : BaseUnityPlugin
     {
         Logger.LogInfo("Scene loadeeeed: " + scene.name);
 
-        while (buttonSrc == null)
-        {
+        while (buttonSrc == null) {
             List<SettingsTABSButton> buttons = FindAllInScene(scene);
-            if (buttons.Count != 0)
+            if (buttons.Count != 0) {
                 buttonSrc = buttons[0].gameObject;
+            }
             yield return new WaitForSeconds(.050f);
         }
 
-        foreach (Transform child in buttonSrc.transform.parent)
-            if (child != buttonSrc.transform)
-                Destroy(child.gameObject);
-
-        Logger.LogInfo("Found TABS/General");
-
-        foreach (var (name, category) in SettingsRegistry.GetPages())
+        if (buttonSrc != null)
         {
-            Logger.LogInfo($"Creating {name} with category {category}");
-            GameObject newButton = Instantiate(buttonSrc, buttonSrc.transform.parent);
-            var loc = newButton.GetComponentInChildren<LocalizedText>();
-            // Fix General tab issue: remove LocalizedText so our custom tab name isn't overwritten
-            if (loc != null) Destroy(loc);
-            SettingsTABSButton tabsButton = newButton.GetComponent<SettingsTABSButton>();
-            tabsButton.category = category;
-            tabsButton.text.text = name;
+            Logger.LogInfo("Found TABS/General");
+
+            foreach (Transform child in buttonSrc.transform.parent)
+                if (child != buttonSrc.transform)
+                    Destroy(child.gameObject);
+
+            foreach (var (name, category) in SettingsRegistry.GetPages())
+            {
+                Logger.LogInfo($"Creating {name} with category {category}");
+                GameObject newButton = Instantiate(buttonSrc, buttonSrc.transform.parent);
+                // Fix General tab issue: prevent LocalizedText overwrite
+                var loc = newButton.GetComponentInChildren<LocalizedText>();
+                if (loc != null)
+                    Destroy(loc);
+                SettingsTABSButton tabsButton = newButton.GetComponent<SettingsTABSButton>();
+                tabsButton.category = category;
+                tabsButton.text.text = name;
+            }
         }
     }
 
@@ -84,7 +98,10 @@ public class Plugin : BaseUnityPlugin
     {
         var result = new List<SettingsTABSButton>();
         foreach (var root in scene.GetRootGameObjects())
-            result.AddRange(root.GetComponentsInChildren<SettingsTABSButton>(true));
+        {
+            var found = root.GetComponentsInChildren<SettingsTABSButton>();
+            result.AddRange(found);
+        }
         return result;
     }
 }
@@ -95,19 +112,29 @@ public class SettingsRegistry
 
     public static void Register(string name)
     {
-        if (nameToCategoryId.ContainsKey(name)) return;
+        if (!nameToCategoryId.ContainsKey(name))
+        {
+            SettingsCategory highestId = Enum.GetValues(typeof(SettingsCategory)).Cast<SettingsCategory>().Max();
+            if (nameToCategoryId.Count != 0)
+            {
+                highestId = nameToCategoryId.Values.Max();
+            }
 
-        int builtInMax = Enum.GetValues(typeof(SettingsCategory)).Cast<int>().Max();
-        int customMax  = nameToCategoryId.Count == 0 ? 0 : nameToCategoryId.Values.Max(v => (int)v);
-        nameToCategoryId[name] = (SettingsCategory)(Math.Max(builtInMax, customMax) + 1);
+            nameToCategoryId[name] = highestId + 1;
+        }
     }
 
-    public static string GetPageId(string name) => nameToCategoryId[name].ToString();
+    public static string GetPageId(string name)
+    {
+        return nameToCategoryId[name].ToString();
+    }
 
-    public static Dictionary<string, SettingsCategory> GetPages() => nameToCategoryId;
+    public static Dictionary<string, SettingsCategory> GetPages() {
+        return nameToCategoryId;
+    }
 }
 
-/* Strip “LOC: ” prefix when localisation key is missing */
+// strip "LOC: " prefix when localisation key is missing
 [HarmonyPatch(typeof(LocalizedText), "GetText", new Type[] { typeof(string), typeof(bool) })]
 static class StripLocPrefixPatch
 {

--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -57,6 +57,7 @@ public class Plugin : BaseUnityPlugin
         }
 
         updateTabsRoutine = StartCoroutine(UpdateTabs(scene));
+        SceneManager.sceneLoaded -= OnSceneLoaded;
     }
 
     private IEnumerator UpdateTabs(Scene scene)
@@ -74,10 +75,6 @@ public class Plugin : BaseUnityPlugin
         if (buttonSrc != null)
         {
             Logger.LogInfo("Found TABS/General");
-
-            foreach (Transform child in buttonSrc.transform.parent)
-                if (child != buttonSrc.transform)
-                    Destroy(child.gameObject);
 
             foreach (var (name, category) in SettingsRegistry.GetPages())
             {


### PR DESCRIPTION
This PR addresses two issues introduced by the recent localization changes in 1.7:

1. **Cloned tabs forced to “General”**  
   The game’s recent update now runs `LocalizedText.RefreshAllText()` on every `SettingsTABSButton`. Buttons instantiated by this plugin didn’t have corresponding localization keys, so they defaulted to the built-in `"GENERAL"` label instead of displaying their custom page names.

2. **Settings display names prefixed with `LOC: `**  
   The updated `SharedSettingsMenu`/`SettingsUICell` flow calls `LocalizedText.GetText()` on each value returned by `GetDisplayName()`. When no entry exists for that key, it returns `"LOC: <key>"`, causing all mod settings to show that debug prefix rather before the key.

## Changes
- **UpdateTabs coroutine**:
  - Removes the `LocalizedText` component from each cloned button before setting its `text`, preventing the “General” overwrite.
- Patch  `LocalizedText.GetText()`:
  - Removes the `"LOC: "` prefix fallback, leaving only the original key.
